### PR TITLE
Update to Stainless 0.7.5

### DIFF
--- a/code/addition/src/main/scala/verifiedall/currency/CurrencyUnits.scala
+++ b/code/addition/src/main/scala/verifiedall/currency/CurrencyUnits.scala
@@ -28,7 +28,7 @@ sealed abstract class Satoshis extends CurrencyUnit {
 }
 
 case object Satoshis extends BaseNumbers[Satoshis] {
-  val zero = Satoshis(Int64.zero)
+  lazy val zero = Satoshis(Int64.zero)
 
   def apply(int64: Int64): Satoshis = SatoshisImpl(int64)
 }

--- a/code/addition/src/main/scala/verifiedall/currency/CurrencyUnits.scala
+++ b/code/addition/src/main/scala/verifiedall/currency/CurrencyUnits.scala
@@ -4,6 +4,7 @@ import verifiedall.number.{BaseNumbers, Int64}
 import stainless.lang._
 
 sealed abstract class CurrencyUnit {
+  type A
   def satoshis: Satoshis
 
   def ==(c: CurrencyUnit): Boolean = satoshis == c.satoshis
@@ -18,6 +19,7 @@ sealed abstract class CurrencyUnit {
 }
 
 sealed abstract class Satoshis extends CurrencyUnit {
+  override type A = Int64
   override def satoshis: Satoshis = this
 
   def toBigInt: BigInt = underlying.toBigInt

--- a/code/addition/src/main/scala/verifiedall/number/NumberType.scala
+++ b/code/addition/src/main/scala/verifiedall/number/NumberType.scala
@@ -1,10 +1,10 @@
 package verifiedall.number
 
 sealed abstract class Number {
-  protected def underlying: BigInt
+  type A = BigInt
+  protected def underlying: A
   def toBigInt: BigInt = underlying
-  def apply: BigInt => Int64
-
+  def apply: A => Int64
   def +(num: Int64): Int64 = {
     require(Int64.isInRange(underlying + num.underlying))
     apply(underlying + num.underlying)
@@ -14,7 +14,7 @@ sealed abstract class Number {
 sealed abstract class SignedNumber extends Number
 
 sealed abstract class Int64 extends SignedNumber {
-  override def apply: BigInt => Int64 = num => {
+  override def apply: A => Int64 = num => {
     require(Int64.isInRange(num))
     Int64(num)
   }


### PR DESCRIPTION
Type members are supported by the most recent version of Stainless (0.7.5)
BaseNumber.zero had to be overridden by a lazy val